### PR TITLE
Random Shuffling Top Rows

### DIFF
--- a/shuffling_top_rows.ipynb
+++ b/shuffling_top_rows.ipynb
@@ -1,0 +1,35 @@
+import sqlite3
+import pandas as pds
+import numpy as nump
+from sklearn.cluster import KMeans
+from sklearn.preprocessing import scale
+from customplot import *
+
+
+# Create your connection.
+conn = sqlite3.connect('database.sqlite')
+df = pds.read_sql_query("SELECT * FROM Player_Attributes", conn)
+
+#df.columns
+
+#df.describe().transpose()
+
+df.isnull().any().any(),df.shape
+
+df.isnull().sum(axis=0)
+
+#Take initial # of rows 
+rows = df.shape[0]
+
+#Drop the Null Rows
+df=df.dropna()
+
+#checking rows
+print(rows)
+
+#To find exactly how many lines we removed, we need to subtract the current number of rows in our data frame from the original number of rows.
+
+rows-df.shape[0]
+
+#shufling to display top rows in randomly at each time running.
+df.reindex(nump.random.permutation(df.index))


### PR DESCRIPTION
Our data table has many lines as you have seen. We can only look at few lines at once. Instead of looking at same top 10 lines every time, we shuffle - so we get to see different random sample on top. This way, we make sure the data is not in any particular order when we try sampling from it (like taking top or bottom few rows) by randomly shuffling the rows.